### PR TITLE
get current branch name

### DIFF
--- a/paint.sh
+++ b/paint.sh
@@ -16,7 +16,14 @@ do
 		git commit --date="$d 12:$m:$s" -m "$i on $d" --no-gpg-sign --allow-empty
 	done
 done < dates.txt
-git push $(git remote show) $(git branch --show-current)
+
+# Get remote name
+a="$(git rev-parse --abbrev-ref HEAD@{u} || echo origin/"$(git rev-parse --abbrev-ref HEAD)")"
+remote="${a%%/*}"
+remote="${remote:-origin}"
+branch="${a#*/}"
+branch="${branch:-master}"
+git push "$remote" HEAD:"$branch"
 
 if [ $? -ne 0 ] ; then
     echo "'git push' failed: please push the current branch to the default branch of a valid github repository"

--- a/paint.sh
+++ b/paint.sh
@@ -16,4 +16,4 @@ do
 		git commit --date="$d 12:$m:$s" -m "$i on $d" --no-gpg-sign --allow-empty
 	done
 done < dates.txt
-git push origin master
+git push origin $(git rev-parse --abbrev-ref HEAD)

--- a/paint.sh
+++ b/paint.sh
@@ -16,4 +16,8 @@ do
 		git commit --date="$d 12:$m:$s" -m "$i on $d" --no-gpg-sign --allow-empty
 	done
 done < dates.txt
-git push origin $(git rev-parse --abbrev-ref HEAD)
+git push $(git origin show) $(git branch --show-current)
+
+if [ $? -ne 0 ] ; then
+    echo "'git push' failed: please push the current branch to the default branch of a valid github repository"
+fi

--- a/paint.sh
+++ b/paint.sh
@@ -16,7 +16,7 @@ do
 		git commit --date="$d 12:$m:$s" -m "$i on $d" --no-gpg-sign --allow-empty
 	done
 done < dates.txt
-git push $(git origin show) $(git branch --show-current)
+git push $(git remote show) $(git branch --show-current)
 
 if [ $? -ne 0 ] ; then
     echo "'git push' failed: please push the current branch to the default branch of a valid github repository"


### PR DESCRIPTION
currently paint.sh assumes a branch name of master. if that is not the current branch name, script fails with a somewhat confusing message about an invalid refspec.

this patch #WorksForMe