### PR TITLE
Use non-discriminating wording

### DIFF
--- a/paint.sh
+++ b/paint.sh
@@ -38,7 +38,7 @@ a="$(git rev-parse --abbrev-ref HEAD@{u} || echo origin/"$(git rev-parse --abbre
 remote="${a%%/*}"
 remote="${remote:-origin}"
 branch="${a#*/}"
-branch="${branch:-master}"
+branch="${branch:-main}"
 git push "$remote" HEAD:"$branch"
 
 if [ $? -ne 0 ] ; then


### PR DESCRIPTION
Replaces master -> main

Doing so also follows the default naming of this repo.